### PR TITLE
release webdriver-precore-0.0.0.3 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Typed definitions for the endpoints of the [W3C Webdriver](https://www.w3.org/TR
 
 This is a library intended to be used as a base for other libraries that provide a WebDriver client implementation and higher level functions.
 
-More info can be found in the [README](./webdriver-precore/README.md) and the [Hackage Docs](https://hackage.haskell.org/package/webdriver-precore-0.0.0.2/candidate)
+More info can be found in the [README](./webdriver-precore/README.md) and the [Hackage Docs](https://hackage.haskell.org/package/webdriver-precore)
 
 ## 2. [webdriver-examples](./webdriver-examples/README.md)
 

--- a/webdriver-examples/ChangeLog.md
+++ b/webdriver-examples/ChangeLog.md
@@ -1,5 +1,9 @@
 # webdriver-examples-??.??.??.?? (????-??-??) - Unreleased
 
+# webdriver-examples-0.0.0.3 (2025-04-21)
+
+No change - examples that work with `webdriver-precore-0.0.0.3`.
+
 # webdriver-examples-0.0.0.2 (2025-04-21)
 
 Examples that work with `webdriver-precore-0.0.0.2`.

--- a/webdriver-examples/webdriver-examples.cabal
+++ b/webdriver-examples/webdriver-examples.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.12
 
 name:           webdriver-examples
-version:        0.0.0.2
+version:        0.0.0.3
 homepage:       https://github.com/pyrethrum/webdriver/webdriver-precore#readme
 bug-reports:    https://github.com/pyrethrum/webdriver/issues
 author:         John Walker, Adrian Glouftsis

--- a/webdriver-precore/ChangeLog.md
+++ b/webdriver-precore/ChangeLog.md
@@ -1,5 +1,9 @@
 # webdriver-precore-??.??.??.?? (????-??-??) - Unreleased
 
+# webdriver-precore-0.0.0.3 (2025-04-21)
+
+A few documentation typos an bump version pof Vector dependencies
+
 # webdriver-precore-0.0.0.2 (2025-04-21)
 
 The initial release of this library.

--- a/webdriver-precore/ChangeLog.md
+++ b/webdriver-precore/ChangeLog.md
@@ -2,7 +2,7 @@
 
 # webdriver-precore-0.0.0.3 (2025-04-21)
 
-A few documentation typos an bump version pof Vector dependencies
+A few documentation typos an bump version of Vector dependencies
 
 # webdriver-precore-0.0.0.2 (2025-04-21)
 

--- a/webdriver-precore/cabal.project
+++ b/webdriver-precore/cabal.project
@@ -1,5 +1,5 @@
 packages: .
-import: https://www.stackage.org/nightly-2025-04-20/cabal.config
+import: https://www.stackage.org/nightly-2025-02-25/cabal.config
 
 multi-repl: True
 

--- a/webdriver-precore/cabal.project
+++ b/webdriver-precore/cabal.project
@@ -1,5 +1,5 @@
 packages: .
-import: https://www.stackage.org/nightly-2025-02-25/cabal.config
+import: https://www.stackage.org/nightly-2025-04-20/cabal.config
 
 multi-repl: True
 

--- a/webdriver-precore/webdriver-precore.cabal
+++ b/webdriver-precore/webdriver-precore.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.12
 
 name:           webdriver-precore
-version:        0.0.0.2
+version:        0.0.0.3
 homepage:       https://github.com/pyrethrum/webdriver-precore#readme
 bug-reports:    https://github.com/pyrethrum/webdriver-precore/issues
 author:         John Walker, Adrian Glouftsis

--- a/webdriver-precore/webdriver-precore.cabal
+++ b/webdriver-precore/webdriver-precore.cabal
@@ -28,7 +28,7 @@ description:
   sending the corresponding HTTP requests to a vendor provided WebDriver, then parsing the response using the parser provided as part 
   of the 'W3Spec' type.
 
-  See "WebDriverPreCore" for further details and [the project repo](https://github.com/pyrethrum/webdriver/blob/main/webdriver-examples/driver-demo-e2e/WebDriverE2EDemoTest.hs) for an examples.
+  See "WebDriverPreCore" for further details and [the project repo](https://github.com/pyrethrum/webdriver) for [examples](https://github.com/pyrethrum/webdriver/blob/main/webdriver-examples/README.md) .
   
   If you are looking for a fully implemented web client library, you should check out an alternative such as [haskell-webdriver](https://github.com/haskell-webdriver/haskell-webdriver#readme).
   

--- a/webdriver-precore/webdriver-precore.cabal
+++ b/webdriver-precore/webdriver-precore.cabal
@@ -124,7 +124,7 @@ library
     base          >=4.16  && <5,
     bytestring    >=0.10  && <0.12.3,
     text          >=2.1   && <2.2,
-    containers    >=0.6   && <0.8,
+    containers    >=0.6   && <0.9,
     vector        >=0.12  && <0.14
   default-language: Haskell2010
 


### PR DESCRIPTION
A few documentation typos an bump version of Vector dependencies